### PR TITLE
fugu: Add keylayout for Xbox360 controllers (Wired and Wireless)

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -233,7 +233,9 @@ PRODUCT_COPY_FILES += \
     device/asus/fugu/gpio-keys.kcm:system/usr/keychars/gpio-keys.kcm \
     device/asus/fugu/Spike.kl:system/usr/keylayout/Spike.kl \
     device/asus/fugu/Nexus_Remote.kl:system/usr/keylayout/Nexus_Remote.kl \
-    device/asus/fugu/keylayout/Vendor_2836_Product_0001.kl:system/usr/keylayout/Vendor_2836_Product_0001.kl
+    device/asus/fugu/keylayout/Vendor_2836_Product_0001.kl:system/usr/keylayout/Vendor_2836_Product_0001.kl \
+    device/asus/fugu/keylayout/Vendor_045e_Product_0719.kl:system/usr/keylayout/Vendor_045e_Product_0719.kl \
+    device/asus/fugu/keylayout/Vendor_045e_Product_028e.kl:system/usr/keylayout/Vendor_045e_Product_028e.kl
 
 #GFX Config
 PRODUCT_COPY_FILES += \

--- a/keylayout/Vendor_045e_Product_028e.kl
+++ b/keylayout/Vendor_045e_Product_028e.kl
@@ -1,0 +1,47 @@
+# Copyright (C) 2011 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# XBox 360 USB Controller
+#
+
+key 304   BUTTON_A
+key 305   BUTTON_B
+key 307   BUTTON_X
+key 308   BUTTON_Y
+key 310   BUTTON_L1
+key 311   BUTTON_R1
+key 314   BACK
+key 315   BUTTON_START
+key 316   HOME
+key 317   BUTTON_THUMBL
+key 318   BUTTON_THUMBR
+
+# Left and right stick.
+# The reported value for flat is 128 out of a range from -32767 to 32768, which is absurd.
+# This confuses applications that rely on the flat value because the joystick actually
+# settles in a flat range of +/- 1024 or so.
+axis 0x00 X flat 1024
+axis 0x01 Y flat 1024
+axis 0x03 Z flat 1024
+axis 0x04 RZ flat 1024
+
+# Triggers.
+axis 0x02 LTRIGGER
+axis 0x05 RTRIGGER
+
+# Hat.
+axis 0x10 HAT_X
+axis 0x11 HAT_Y
+

--- a/keylayout/Vendor_045e_Product_0719.kl
+++ b/keylayout/Vendor_045e_Product_0719.kl
@@ -1,0 +1,47 @@
+# Copyright (C) 2011 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# XBox 360 Wireless USB Controller
+#
+
+key 304   BUTTON_A
+key 305   BUTTON_B
+key 307   BUTTON_X
+key 308   BUTTON_Y
+key 310   BUTTON_L1
+key 311   BUTTON_R1
+key 314   BACK
+key 315   BUTTON_START
+key 316   HOME
+key 317   BUTTON_THUMBL
+key 318   BUTTON_THUMBR
+
+# Left and right stick.
+# The reported value for flat is 128 out of a range from -32767 to 32768, which is absurd.
+# This confuses applications that rely on the flat value because the joystick actually
+# settles in a flat range of +/- 1024 or so.
+axis 0x00 X flat 1024
+axis 0x01 Y flat 1024
+axis 0x03 Z flat 1024
+axis 0x04 RZ flat 1024
+
+# Triggers.
+axis 0x02 LTRIGGER
+axis 0x05 RTRIGGER
+
+# Hat.
+axis 0x10 HAT_X
+axis 0x11 HAT_Y
+


### PR DESCRIPTION
Add keylayout for wired and wireless Xbox360 controllers. Fixes the issue where a wireless controller is assigned the Generic.kl and as a result the right joystick and analog triggers are not mapped correctly and the deadzones are defaulted to 128. This sets the deadzones to 1024 and fixes the axis mapping for both the wired and wireless usb xbox360 controllers.